### PR TITLE
Fix warnings in Godot v3.2.2

### DIFF
--- a/Phoenix/Scripts/Channel.gd
+++ b/Phoenix/Scripts/Channel.gd
@@ -53,11 +53,11 @@ func _init(socket, topic : String, params : Dictionary = {}, presence = null):
 	
 	_rejoin_timer = Timer.new()
 	_rejoin_timer.set_autostart(false)
-	_rejoin_timer.connect("timeout", self, "_on_Timer_timeout")
+	var _error = _rejoin_timer.connect("timeout", self, "_on_Timer_timeout")
 	add_child(_rejoin_timer)
 	
 func _exit_tree():
-	leave()
+	var _success = leave()
 	
 	"""
 	Leaving the channel with leave() leads to the chain of events that eventually call on_close,
@@ -85,7 +85,7 @@ func get_topic() -> String:
 
 func leave() -> bool:
 	if !is_leaving() and !is_closed():
-		push(CHANNEL_EVENTS.leave, {})
+		var _success = push(CHANNEL_EVENTS.leave, {})
 		_state = ChannelStates.LEAVING
 		return true
 		
@@ -180,7 +180,7 @@ func trigger(message : PhoenixMessage):
 				var pending_event = _get_pending_ref(message.get_ref())
 				if pending_event:
 					event = pending_event
-					_pending_refs.erase(message.get_ref())
+					var _success = _pending_refs.erase(message.get_ref())
 
 			if event != CHANNEL_EVENTS.leave:
 				emit_signal("on_event", event, message.get_response(), status)
@@ -243,4 +243,4 @@ func _get_pending_ref(ref):
 func _on_Timer_timeout():
 	if _should_rejoin_until_connected:
 		if not _joined_once:
-			_rejoin()
+			var _success = _rejoin()

--- a/Phoenix/Scripts/Message.gd
+++ b/Phoenix/Scripts/Message.gd
@@ -8,16 +8,19 @@ const GLOBAL_JOIN_REF := ""
 var _message : Dictionary = {} setget ,to_dictionary
 
 func _init(topic : String, event : String, ref : String = NO_REPLY_REF, join_ref : String = GLOBAL_JOIN_REF, payload : Dictionary = {}):
-	var final_join_ref = join_ref if join_ref != GLOBAL_JOIN_REF else null
-	var final_ref = ref if ref != NO_REPLY_REF else null
-	
 	_message = {
 		topic = topic,
 		event = event,
 		payload = payload,
-		ref = final_ref,
-		join_ref = final_join_ref
+		ref = null,
+		join_ref = null
 	}
+	
+	if join_ref != NO_REPLY_REF:
+		_message.ref = ref
+		
+	if join_ref != GLOBAL_JOIN_REF:
+		_message.join_ref = join_ref
 
 func get_topic() -> String: return _message.topic
 func get_event() -> String: return _message.event

--- a/Phoenix/Scripts/Presence.gd
+++ b/Phoenix/Scripts/Presence.gd
@@ -82,7 +82,7 @@ func sync_diff(diff : Dictionary) -> Dictionary:
 			})	
 			
 			if current_presence.metas.size() == 0:
-				_state.erase(key)
+				var _success = _state.erase(key)
 	
 	if emit_joins.size() > 0:
 		emit_signal("on_join", emit_joins)

--- a/Phoenix/Scripts/Utils.gd
+++ b/Phoenix/Scripts/Utils.gd
@@ -35,17 +35,17 @@ static func get_message_from_dictionary(from : Dictionary = {}) -> PhoenixMessag
 	return PhoenixMessage.new(from.topic, from.event, ref, join_ref, from.payload)
 	
 static func map(function: FuncRef, array: Array) -> Array:
-    var o_array := []	
-    for value in array:
-        o_array.append(function.call_func(value))
+	var o_array := []	
+	for value in array:
+		o_array.append(function.call_func(value))
 		
-    return o_array
+	return o_array
 	
 static func filter(function: FuncRef, array: Array) -> Array:
-    var filtered_array := []
+	var filtered_array := []
 
-    for candidate_value in array:
-        if function.call_func(candidate_value):
-            filtered_array.append(candidate_value)
+	for candidate_value in array:
+		if function.call_func(candidate_value):
+			filtered_array.append(candidate_value)
 
-    return filtered_array
+	return filtered_array


### PR DESCRIPTION
Unused variables and inconsistent types in ternary operators were causing warnings in Godot v3.2.2. Since the editor doesn't allow us to disable warnings for specific files at the moment, I suggest the following changes which remove all of these warnings.

P.S.: It appears indentation and end of file fixes have sneaked in this PR, courtesy of my text editor. I hope that's okay.