### PR TITLE
Fix bug when joining channels introduced by #23

### DIFF
--- a/Phoenix/Scripts/Message.gd
+++ b/Phoenix/Scripts/Message.gd
@@ -16,7 +16,7 @@ func _init(topic : String, event : String, ref : String = NO_REPLY_REF, join_ref
 		join_ref = null
 	}
 	
-	if join_ref != NO_REPLY_REF:
+	if ref != NO_REPLY_REF:
 		_message.ref = ref
 		
 	if join_ref != GLOBAL_JOIN_REF:


### PR DESCRIPTION
It appears I broke everything 😇

Due to a typo in my earlier PR (#23), channel join events would no longer trigger. They were treated as normal replies. This is now fixed, sorry for the trouble!